### PR TITLE
ターン表示をシンプルなテキストに変更

### DIFF
--- a/Othello/Views/OthelloBoardView.swift
+++ b/Othello/Views/OthelloBoardView.swift
@@ -15,7 +15,7 @@ struct OthelloBoardView: View {
     var body: some View {
         VStack {
             // 現在のプレイヤーまたはゲーム結果を表示
-            Text(viewModel.isGameOver ? viewModel.gameOverText : "現在のプレイヤー: \(viewModel.currentPlayer == .black ? "黒" : "白")")
+            Text(viewModel.isGameOver ? viewModel.gameOverText : "\(viewModel.currentPlayer == .black ? "黒" : "白")のターン")
                 .font(.title)
                 .padding()
             


### PR DESCRIPTION
「現在のプレイヤー: 黒」「現在のプレイヤー: 白」を
「黒のターン」「白のターン」に変更しました。
視覚的な強調やレイアウトは維持しています。